### PR TITLE
Refactor to use String instead of ApiKey class.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,8 +55,10 @@ public class MyConfiguration implements ApiKeyBundleConfiguration {
 ```
 
 Now you can use API key based authentication in your application by declaring a method on a resource
-that has an `@Auth` annotated `ApiKey` parameter.  See the
-[Dropwizard Authentication][authentication] documentation for more details.
+that has an `@Auth` annotated `String` parameter.  See the
+[Dropwizard Authentication][authentication] documentation for more details.  The passed in parameter
+value will be the name of the application that made the request if the authentication process was
+successful.
 
 As far as configuration goes you can define your API keys in your application's config file.
 Assuming, like in the above example, you called your API key configuration element `authentication`

--- a/src/main/java/io/dropwizard/bundles/apikey/ApiKeyBundle.java
+++ b/src/main/java/io/dropwizard/bundles/apikey/ApiKeyBundle.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkState;
  * An API key bundle that allows you to configure a set of users/applications that are allowed to
  * access APIs of the application in the Dropwizard configuration file.
  */
+@SuppressWarnings("UnusedDeclaration")
 public class ApiKeyBundle<T extends ApiKeyBundleConfiguration> implements ConfiguredBundle<T> {
   @Override
   public void initialize(Bootstrap<?> bootstrap) {
@@ -31,13 +32,13 @@ public class ApiKeyBundle<T extends ApiKeyBundleConfiguration> implements Config
     Optional<AuthConfiguration> basic = configuration.getBasicConfiguration();
     checkState(basic.isPresent(), "A basic-http configuration option must be specified");
 
-    AuthFactory<?, ApiKey> factory = createBasicAuthFactory(basic.get(), environment.metrics());
+    AuthFactory<?, String> factory = createBasicAuthFactory(basic.get(), environment.metrics());
     environment.jersey().register(AuthFactory.binder(factory));
   }
 
-  private BasicAuthFactory<ApiKey> createBasicAuthFactory(AuthConfiguration config,
+  private BasicAuthFactory<String> createBasicAuthFactory(AuthConfiguration config,
                                                           MetricRegistry metrics) {
-    Authenticator<BasicCredentials, ApiKey> authenticator = createAuthenticator(config);
+    Authenticator<BasicCredentials, String> authenticator = createAuthenticator(config);
 
     Optional<String> cacheSpec = config.getCacheSpec();
     if (cacheSpec.isPresent()) {
@@ -45,10 +46,10 @@ public class ApiKeyBundle<T extends ApiKeyBundleConfiguration> implements Config
       authenticator = new CachingAuthenticator<>(metrics, authenticator, spec);
     }
 
-    return new BasicAuthFactory<>(authenticator, config.getRealm(), ApiKey.class);
+    return new BasicAuthFactory<>(authenticator, config.getRealm(), String.class);
   }
 
-  private Authenticator<BasicCredentials, ApiKey> createAuthenticator(AuthConfiguration config) {
+  private Authenticator<BasicCredentials, String> createAuthenticator(AuthConfiguration config) {
     Map<String, ApiKey> keys = config.getApiKeys();
     return new BasicCredentialsAuthenticator(keys::get);
   }

--- a/src/main/java/io/dropwizard/bundles/apikey/BasicCredentialsAuthenticator.java
+++ b/src/main/java/io/dropwizard/bundles/apikey/BasicCredentialsAuthenticator.java
@@ -10,7 +10,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * An Authenticator that converts HTTP basic authentication credentials into an API key.
  */
-public class BasicCredentialsAuthenticator implements Authenticator<BasicCredentials, ApiKey> {
+public class BasicCredentialsAuthenticator implements Authenticator<BasicCredentials, String> {
   private final ApiKeyProvider provider;
 
   BasicCredentialsAuthenticator(ApiKeyProvider provider) {
@@ -18,7 +18,7 @@ public class BasicCredentialsAuthenticator implements Authenticator<BasicCredent
   }
 
   @Override
-  public Optional<ApiKey> authenticate(BasicCredentials credentials)
+  public Optional<String> authenticate(BasicCredentials credentials)
       throws AuthenticationException {
     checkNotNull(credentials);
 
@@ -34,6 +34,6 @@ public class BasicCredentialsAuthenticator implements Authenticator<BasicCredent
       return Optional.absent();
     }
 
-    return Optional.of(key);
+    return Optional.of(key.getUsername());
   }
 }

--- a/src/test/java/io/dropwizard/bundles/apikey/ApiKeyBundleClientTest.java
+++ b/src/test/java/io/dropwizard/bundles/apikey/ApiKeyBundleClientTest.java
@@ -31,7 +31,7 @@ public class ApiKeyBundleClientTest {
 
     @GET
     @Path("/secure")
-    public String secure(@Auth ApiKey key) {
+    public String secure(@Auth String application) {
       return "secure";
     }
   }
@@ -55,7 +55,7 @@ public class ApiKeyBundleClientTest {
   @Rule
   public final ResourceTestRule resources = ResourceTestRule.builder()
       .setTestContainerFactory(new GrizzlyWebTestContainerFactory())
-      .addProvider(AuthFactory.binder(new BasicAuthFactory<>(authenticator, "realm", ApiKey.class)))
+      .addProvider(AuthFactory.binder(new BasicAuthFactory<>(authenticator, "realm", String.class)))
       .addResource(new TestResource())
       .build();
 

--- a/src/test/java/io/dropwizard/bundles/apikey/BasicCredentialsAuthenticatorTest.java
+++ b/src/test/java/io/dropwizard/bundles/apikey/BasicCredentialsAuthenticatorTest.java
@@ -22,24 +22,22 @@ public class BasicCredentialsAuthenticatorTest {
 
   @Test
   public void testValidCredentials() throws AuthenticationException {
-    ApiKey expected = mock(ApiKey.class);
-    when(expected.getSecret()).thenReturn("secret");
-    when(provider.get("username")).thenReturn(expected);
+    ApiKey key = newKey("username", "secret");
+    when(provider.get("username")).thenReturn(key);
 
     BasicCredentials credentials = new BasicCredentials("username", "secret");
-    Optional<ApiKey> actual = auth.authenticate(credentials);
+    Optional<String> actual = auth.authenticate(credentials);
     assertTrue(actual.isPresent());
-    assertEquals(expected, actual.get());
+    assertEquals("username", actual.get());
   }
 
   @Test
   public void testInvalidCredentials() throws AuthenticationException {
-    ApiKey expected = mock(ApiKey.class);
-    when(expected.getSecret()).thenReturn("not-a-secret");
-    when(provider.get("username")).thenReturn(expected);
+    ApiKey key = newKey("username", "not-a-secret");
+    when(provider.get("username")).thenReturn(key);
 
     BasicCredentials credentials = new BasicCredentials("username", "secret");
-    Optional<ApiKey> actual = auth.authenticate(credentials);
+    Optional<String> actual = auth.authenticate(credentials);
     assertFalse(actual.isPresent());
   }
 
@@ -48,7 +46,15 @@ public class BasicCredentialsAuthenticatorTest {
     when(provider.get("username")).thenReturn(null);
 
     BasicCredentials credentials = new BasicCredentials("username", "secret");
-    Optional<ApiKey> actual = auth.authenticate(credentials);
+    Optional<String> actual = auth.authenticate(credentials);
     assertFalse(actual.isPresent());
+  }
+
+  private ApiKey newKey(String username, String secret) {
+    ApiKey key = mock(ApiKey.class);
+    when(key.getUsername()).thenReturn(username);
+    when(key.getSecret()).thenReturn(secret);
+
+    return key;
   }
 }


### PR DESCRIPTION
This change refactors the object that is returned after a successful
authorization operation.  Instead of an ApiKey object like was
previously returned, a java.lang.String is now just returned.  This
string is the name of the application that made the request.  This
change feels right in a few ways.  First it makes the implementation
of service methods simpler because they have less to worry about
because they're only receiving a string instead of some random
object from a library.  Secondly by returning a string instead of
the full ApiKey object we're preventing code that doesn't need to
have access to the API key secret from having direct access to it.
This strictly isn't a huge deal, but it feels more correct than
passing it around everywhere.
